### PR TITLE
Fixed mapbox API change

### DIFF
--- a/src/main/resources/web/controllers/main-controller.js
+++ b/src/main/resources/web/controllers/main-controller.js
@@ -40,9 +40,8 @@ angular.module("crowd").controller("MainController", function($scope, $rootScope
     }
 
     $scope.tiles = {
-        url: "https://api.mapbox.com/v4/{mapId}/{z}/{x}/{y}.png?access_token={accessToken}",
+        url: "https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/256/{z}/{x}/{y}?access_token={accessToken}",
         options: {
-            mapId: 'jri.2eeeaa1d',
             accessToken: 'pk.eyJ1IjoianJpIiwiYSI6ImNpaG5ubmtsdDAwaHB1bG00aGk1c3BhamcifQ.2XkYFs4hGOel8DYCy4qKKw',
             attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a>, ' +
                 'Imagery &copy; <a href="http://mapbox.com">Mapbox</a>'


### PR DESCRIPTION
The map on https://crowdlit.net/eu.crowd-literature was no longer displayed because of an API change on the mapbox side. This commit fixes the issue.